### PR TITLE
fix: declare library functions as internal

### DIFF
--- a/src/DevOpsTools.sol
+++ b/src/DevOpsTools.sol
@@ -16,7 +16,7 @@ library DevOpsTools {
     function get_most_recent_deployment(
         string memory contractName,
         uint256 chainId
-    ) public returns (address) {
+    ) internal returns (address) {
         return
             get_most_recent_deployment(
                 contractName,
@@ -28,7 +28,7 @@ library DevOpsTools {
 
     function cleanStringPath(
         string memory stringToClean
-    ) public pure returns (string memory) {
+    ) internal pure returns (string memory) {
         bytes memory inputBytes = bytes(stringToClean);
         uint256 start = 0;
         uint256 end = inputBytes.length;
@@ -70,7 +70,7 @@ library DevOpsTools {
         uint256 chainId,
         string memory relativeBroadcastPath,
         string memory relativeScriptPath
-    ) public returns (address) {
+    ) internal returns (address) {
         relativeBroadcastPath = cleanStringPath(relativeBroadcastPath);
         relativeScriptPath = cleanStringPath(relativeScriptPath);
 


### PR DESCRIPTION
# Description

Declare DevOpsTools library functions as internal to avoid deploying a `DevOpsTools` contract onchain when interacting with foundry scripts.

Currently `DevOpsTools` contract is deployed (even when the call is made before `startBroadcast`)
<img width="1367" alt="image" src="https://github.com/Cyfrin/foundry-devops/assets/1694104/0c2b2476-ed5c-403d-b43d-abf228d9f4e0">

Context: https://github.com/Cyfrin/foundry-full-course-f23/discussions/590#discussioncomment-6726532

## Tests

I tested this changes by using the `Interactions` scripts from the [foundry-fund-me](https://github.com/Cyfrin/foundry-fund-me-f23) repo.
- Patch the installed library directly from the lib folder: `lib/foundry-devops/src/DevOpsTools.sol`
- Use make to deploy and fund the contract on sepolia and verify that the `DevOpsTools` contract hasn't been deployed.

<img width="1351" alt="image" src="https://github.com/Cyfrin/foundry-devops/assets/1694104/4ff47bd4-72a9-4752-a279-1cb8de7e071c">
