### PR TITLE
Make logic cleaner

### DIFF
--- a/test/DevOpsToolsTest.t.sol
+++ b/test/DevOpsToolsTest.t.sol
@@ -10,7 +10,7 @@ contract DevOpsToolsTest is Test {
     function testGetMostRecentlyDeployedContract() public {
         string memory contractName = "Stuff";
         uint256 chainId = 31337;
-        address expectedAddress = 0xa513E6E4b8f2a923D98304ec87F64353C4D5C853;
+        address expectedAddress = 0x5FbDB2315678afecb367f032d93F642f64180aa3;
         address mostRecentDeployment = DevOpsTools.get_most_recent_deployment(
             contractName,
             chainId,
@@ -34,7 +34,7 @@ contract DevOpsToolsTest is Test {
     function testExpectRevertIfNoRun() public {
         string memory contractName = "FundMe";
         uint256 chainId = 9999;
-        vm.expectRevert("No run-latest.json file found for specified chain");
+        vm.expectRevert("No deployment artifacts were found for specified chain");
         DevOpsTools.get_most_recent_deployment(
             contractName,
             chainId,


### PR DESCRIPTION
Nice tool! This PR makes logic cleaner and more stable (removes dependency on certail broadcast artifact formats)

Here's the full list of changes:
1. Instead of decoding into structs, just iterate over `.transactions` and read `.contractName` and `.contractAddress` which are always present
2. Update file fitering logic to include all `.json` files and exclude all artifacts from `dry-run` directories.
3. Fix `lastTimestamp` logic. It was never updated before and it caused incorrect contract being found as first deployments
4. Fix tests which were failing because of issue above