### PR TITLE
Change visibility of get_most_recent_deployment function to internal

### DIFF
--- a/src/DevOpsTools.sol
+++ b/src/DevOpsTools.sol
@@ -67,7 +67,7 @@ library DevOpsTools {
 
     string public constant RELATIVE_BROADCAST_PATH = "./broadcast";
 
-    function get_most_recent_deployment(string memory contractName, uint256 chainId) public view returns (address) {
+    function get_most_recent_deployment(string memory contractName, uint256 chainId) internal view returns (address) {
         return get_most_recent_deployment(contractName, chainId, RELATIVE_BROADCAST_PATH);
     }
 


### PR DESCRIPTION
This PR fixes the issue where the library was unnecessarily getting deployed on-chain whenever ```get_most_recent_deployment``` function is called from ```DevOpsTools``` library.
By changing the visibility of ```get_most_recent_deployment``` to internal, the library will not get deployed.