### PR TITLE
avoid deployment of library contract

### DIFF
--- a/script/InteractWithStuff.s.sol
+++ b/script/InteractWithStuff.s.sol
@@ -7,7 +7,7 @@ import {Stuff} from "./DeployStuff.s.sol";
 
 contract InteractWithStuff is Script {
     function run() external {
-        address mostRecent = DevOpsTools.get_most_recent_deployment("DeployStuff", block.chainid);
+        address mostRecent = DevOpsTools.get_most_recent_deployment("Stuff", block.chainid);
         uint256 value = Stuff(mostRecent).getSeven();
         assert(value == 7);
     }

--- a/src/DevOpsTools.sol
+++ b/src/DevOpsTools.sol
@@ -25,7 +25,7 @@ library DevOpsTools {
         string memory contractName,
         uint256 chainId,
         string memory relativeBroadcastPath
-    ) public view returns (address) {
+    ) internal view returns (address) {
         address latestAddress = address(0);
         uint256 lastTimestamp;
 


### PR DESCRIPTION
currently every script that is using the library is deploying an additional "DevOpsTools" contract because of
https://github.com/foundry-rs/foundry/issues/3295

that foundry bug makes the lib completely useless for mainnet.

I changed the lib function to be  internal.
(includes also a small fix for the interactwithstuff script using a wrong contract name.)

closes https://github.com/Cyfrin/foundry-devops/issues/18