### PR TITLE
refactor: improve error message for not found contracts

### DIFF
--- a/src/DevOpsTools.sol
+++ b/src/DevOpsTools.sol
@@ -60,7 +60,11 @@ library DevOpsTools {
         if (latestAddress != address(0)) {
             return latestAddress;
         } else {
-            revert("No contract deployed");
+            revert(
+                string.concat(
+                    "No contract named ", "'", contractName, "'", " has been deployed on chain ", vm.toString(chainId)
+                )
+            );
         }
     }
 

--- a/test/DevOpsToolsTest.t.sol
+++ b/test/DevOpsToolsTest.t.sol
@@ -35,7 +35,16 @@ contract DevOpsToolsTest is Test, ZkSyncChainChecker, FoundryZkSyncChecker {
     function testExpectRevertIfNoDeployment() public skipZkSync onlyVanillaFoundry {
         string memory contractName = "MissingContract";
         uint256 chainId = 1234;
-        vm.expectRevert("No contract deployed");
+        vm.expectRevert(
+            bytes.concat(
+                "No contract named ",
+                "'",
+                bytes(contractName),
+                "'",
+                " has been deployed on chain ",
+                bytes(vm.toString(chainId))
+            )
+        );
         DevOpsTools.get_most_recent_deployment(contractName, chainId, SEARCH_PATH);
     }
 


### PR DESCRIPTION
## Problem
When setting up a script to automatically deploy a smart contract with other contracts in its parameters, I encountered an error due to a missing contract deployment. However, the error did not specify which contract was missing

## Solution
I have added a more descriptive revert message that includes the contract name and chain ID when a contract is not found. This improves the developer experience for users of the tool 🙂

### Before
![before](https://github.com/user-attachments/assets/9fd3f627-4a21-480c-819d-d73dc778460b)

### After
![after](https://github.com/user-attachments/assets/cef88949-5a83-4e92-b34e-2d58f29076a7)