### PR TITLE
Update DevOpsTools.sol

### DIFF
--- a/src/DevOpsTools.sol
+++ b/src/DevOpsTools.sol
@@ -101,7 +101,7 @@ library DevOpsTools {
         // Replace backslashes with forward slashes
         bytes memory b = bytes(path);
         for (uint256 i = 0; i < b.length; i++) {
-            if (b[i] == "\\") {
+            if (b[i] == bytes1("\\")) {
                 b[i] = "/";
             }
         }


### PR DESCRIPTION
Without this fix, the original comparison b[i] == "\\" causes a type mismatch because "\\" is interpreted as a string, not a bytes1 value. The updated code uses bytes1("\\"), which properly resolves the character to its byte representation, allowing correct detection and replacement of backslashes (\) in paths.

This ensures that normalizePath() behaves as expected and avoids potential runtime errors or incorrect path normalization.

