### PR TITLE
forge install fix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ It will look through your `broadcast` folder at your most recent deployment.
 ## Installation
 
 ```bash
-forge install Cyfrin/foundry-devops --no-commit
+forge install Cyfrin/foundry-devops
 ```
 
 - Update forge-std to use newer FS cheatcodes
@@ -47,7 +47,7 @@ git rm -rf lib/forge-std
  rm -rf lib/forge-std
 ```
 ```
- forge install foundry-rs/forge-std@v1.8.2 --no-commit
+ forge install foundry-rs/forge-std@v1.8.2 
 ```
 
 ## Usage - Getting the most recent deployment


### PR DESCRIPTION
forge does not commit by default when installing dependencies anymore as of 2025.
if we want to commit it we can do ```forge install --commit```

and doing ```forge install --no-commit``` will give ```unexpected argument '--no-commit' found```