### PR TITLE
fix: function is_foundry_zksync

### DIFF
--- a/src/FoundryZkSyncChecker.sol
+++ b/src/FoundryZkSyncChecker.sol
@@ -35,7 +35,7 @@ abstract contract FoundryZkSyncChecker is Test {
     error FoundryZkSyncChecker__UnknownFoundryVersion();
 
     /**
-     * @notice returns the current version of foundry.
+     * @notice returns if the foundry version is foundry-zksync or not.
      */
     function is_foundry_zksync() public returns (bool) {
         string[] memory forgeVersionCommand = new string[](2);
@@ -43,6 +43,15 @@ abstract contract FoundryZkSyncChecker is Test {
         forgeVersionCommand[1] = "--version";
         bytes memory retData = vm.ffi(forgeVersionCommand);
         console2.logBytes(retData);
+
+        string memory forgeVersionStr = string(retData);
+        bytes memory forgeVersionInLowerCase = _convertBytesToLowerCase(retData);
+
+        // Check for `zksync`substring in the forge version string
+        if (_containsSubstring(forgeVersionInLowerCase, bytes("zksync"))) {
+            console2.log("This is Foundry ZkSync");
+            return true;
+        }
 
         uint256 prefix_length = POST_THREE_PREFIX_LENGTH;
         for (uint256 i = 0; i < POST_THREE_PREFIX_LENGTH; i++) {
@@ -68,7 +77,7 @@ abstract contract FoundryZkSyncChecker is Test {
             forgeVersionPrefixed[i] = retData[i];
         }
         string memory forgePrefixedStr = string(forgeVersionPrefixed);
-        console2.log("Got forge version:", forgePrefixedStr);
+        console2.log("Got forge version:", forgeVersionStr);
 
         console2.logBytes32(bytes32(forgeVersionPrefixed));
         console2.logBytes32(bytes32(FORGE_VERSION_0_3_));
@@ -87,6 +96,41 @@ abstract contract FoundryZkSyncChecker is Test {
         }
         console2.log("Unknown forge version");
         revert FoundryZkSyncChecker__UnknownFoundryVersion();
+    }
+
+    // Helper function to convert bytes to lowercase
+    function _convertBytesToLowerCase(bytes memory data) private pure returns (bytes memory) {
+            bytes memory result = new bytes(data.length);
+            for (uint256 i = 0; i < data.length; i++) {
+                // Convert uppercase A-Z (65-90) to lowercase a-z (97-122)
+                if (data[i] >= 0x41 && data[i] <= 0x5A) {
+                    result[i] = bytes1(uint8(data[i]) + 32);
+                } else {
+                    result[i] = data[i];
+                }
+            }
+            return result;
+    }
+
+    // Helper function to check if `data` contains `substring`
+    function _containsSubstring(bytes memory data, bytes memory substring) private pure returns (bool) {
+        if (data.length < substring.length) {
+            return false;
+        }
+
+        for (uint256 i = 0; i <= data.length - substring.length; i++) {
+            bool found = true;
+            for (uint256 j = 0; j < substring.length; j++) {
+                if (data[i + j] != substring[j]) {
+                    found = false;
+                    break;
+                }
+            }
+            if (found) {
+                return true;
+            }
+        }
+        return false;
     }
 
     modifier onlyFoundryZkSync() {


### PR DESCRIPTION
## Issue
The function `is_foundry_zksync` does not recognise if the system has `Foundry Base Installation` or `Foundry zkSync` installed. It will always return
```
This is Vanilla Foundry
```

## Steps to reproduce the issue
From Course : Foundry Fundamentals > [Lesson 25 - Zksync Devops](https://updraft.cyfrin.io/courses/foundry/foundry-fund-me/zksync-devops)
Project: [foundry-fund-me-cu](https://github.com/Cyfrin/foundry-fund-me-cu)
Test File: [test/unit/ZkSyncDevOps.t.sol](https://github.com/Cyfrin/foundry-fund-me-cu/blob/main/test/unit/ZkSyncDevOps.t.sol)
Note: Have `ffi = true` in the `foundry.toml`
Run first
```
foundryup-zksync
```
and then
```
forge test --mt testZkSyncFoundryFails -vvvv
```

## Root Cause
The command 
```
forge --version
```
that it's being run in these [lines of code](https://github.com/Cyfrin/foundry-devops/blob/efff097a87e70c3d15661c9f2a2daeae0b33d5d5/src/FoundryZkSyncChecker.sol#L42L44)
```
function is_foundry_zksync() public returns (bool) {
	string[] memory forgeVersionCommand = new string[](2);
	forgeVersionCommand[0] = "forge";
	forgeVersionCommand[1] = "--version";
	bytes memory retData = vm.ffi(forgeVersionCommand);
```

in the Foundry Base installation it returns
```
forge Version: 1.3.2-stable
```

and in Foundry zkSync installation it returns
```
forge Version: 1.3.0-foundry-zksync-v0.0.26
```

With the following checks in that function, only the first part of the returned string is checked which is the version (`forge Version: 1.`) and it is the same in both cases (Foundry Base Installation and Foundry zkSync Installation).

So when the code arrives at this [check](https://github.com/Cyfrin/foundry-devops/blob/efff097a87e70c3d15661c9f2a2daeae0b33d5d5/src/FoundryZkSyncChecker.sol#L76L81), it only checks for the version of the installation hence this `if` statement will be fulfilled and the code will go in the corresponding statements which is the following
```
	console2.log("This is Vanilla Foundry");
	return false;
```

## Suggested Solution
After running the command
```
forge --version
```
check if the returned string contains the substring `zksync`. If yes, return the corresponding msg and boolean value.

## Notes

### Note 1
I am not sure if the checks of specific versions are necessary. If we just add 2 more checks after the suggested solution, e.g.
```
// If it contains standard foundry indicators, it's vanilla
if (_containsSubstring(lowerVersion, bytes("forge"))) {
	console2.log("This is Vanilla Foundry");
	return false;
}

console2.log("Unknown forge version");
revert FoundryZkSyncChecker__UnknownFoundryVersion();
```
we could remove all the rest of the checks.

### Note 2
I do not understand why `skipZkSync` modifier uses another function `isZkSyncChain` and then another function `isOnZkSyncChainId` to again determine if we are on zkSync or not. We could use the same function.

## Additional changes

### Change 1
Replaced 
```
console2.log("Got forge version:", forgePrefixedStr);
```

which results in
```
Got forge version:", "forge Version: 1.
```

with 
```
console2.log("Got forge version:", forgeVersionStr);
```
 which results in
 ```
 Got forge version:", "forge Version: 1.3.0-foundry-zksync-v0.0.26
 ```
which looks more like what I would expect to see in the forge version.

### Change 2
Replaced the natspec of the function `is_foundry_zksync` since it does not return the current version of foundry. It returns if the Foundry installation is the base one or the zksync one. 


## Testing
- git clone [foundry-devops](https://github.com/Imod7/foundry-devops/tree/main)  
- checkout in my branch
- git clone also [foundry-fund-me-cu](https://github.com/Cyfrin/foundry-fund-me-cu) in a separate folder
	- edit the `unti/test/ZkSyncDevOps.t.sol` file and change the import of `FoundryZkSyncChecker` to point to the cloned repo (previous step) of foundry-devops (use the absolute path)
	- enable `ffi = true` in your `foundry.toml`

In your `foundry-fund-me-cu` folder:

`Foundry-zkSync`
- Run `foundryup-zksync`
- When you run `forge --version`, it should return something similar to `forge Version: 1.3.0-foundry-zksync-v0.0.26`
- Uncomment the test `testZkSyncFoundryFails` and run `forge test --mt testZkSyncFoundryFails -vvvv` 
- it should pass (because zkSync now supports `keyExistsJson`) and returns `This is Foundry ZkSync`

`Foundry`
- Run `foundryup`
- When you run `forge --version`, it should return something similar to `forge Version: 1.3.2-stable`
- Run again the test `forge test --mt testZkSyncFoundryFails -vvvv`
- It should returns `This is Vanilla Foundry`