### PR TITLE
Add HelperConfig for network management

### DIFF
--- a/src/HelperConfig.sol
+++ b/src/HelperConfig.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {Script} from "forge-std/Script.sol";
+
+contract HelperConfig is Script {
+    // Types
+    struct NetworkConfig {
+        string name;
+        uint256 chainId;
+    }
+
+    // Constants
+    uint256 public constant ETH_MAINNET_CHAIN_ID = 1;
+    uint256 public constant ETH_SEPOLIA_CHAIN_ID = 11155111;
+    uint256 public constant LOCAL_CHAIN_ID = 31337;
+
+    //  State Variables
+    NetworkConfig public activeNetworkConfig;
+    
+    // Local network state variables
+    NetworkConfig public localNetworkConfig;
+    mapping(uint256 => NetworkConfig) public networkConfigs;
+
+    constructor() {
+        // Initialize network configurations
+        networkConfigs[ETH_MAINNET_CHAIN_ID] = getMainnetEthConfig();
+        networkConfigs[ETH_SEPOLIA_CHAIN_ID] = getSepoliaEthConfig();
+        
+        if (block.chainid == ETH_SEPOLIA_CHAIN_ID) {
+            activeNetworkConfig = getSepoliaEthConfig();
+        } else if (block.chainid == ETH_MAINNET_CHAIN_ID) {
+            activeNetworkConfig = getMainnetEthConfig();
+        } else {
+            activeNetworkConfig = getOrCreateAnvilEthConfig();
+        }
+    }
+
+    /**
+     * @notice Get the configuration for a specific chain ID
+     * @param chainId The chain ID to get configuration for
+     * @return NetworkConfig for the specified chain
+     */
+    function getConfigByChainId(uint256 chainId) public returns (NetworkConfig memory) {
+        if (networkConfigs[chainId].chainId != 0) {
+            return networkConfigs[chainId];
+        } else if (chainId == LOCAL_CHAIN_ID) {
+            return getOrCreateAnvilEthConfig();
+        } else {
+            // Return empty config for unknown chains
+            return NetworkConfig({
+                name: "",
+                chainId: 0
+            });
+        }
+    }
+
+    /**
+     * @notice Set a custom configuration for a chain ID
+     * @param chainId The chain ID to set configuration for
+     * @param networkConfig The configuration to set
+     */
+    function setConfig(uint256 chainId, NetworkConfig memory networkConfig) public {
+        networkConfigs[chainId] = networkConfig;
+    }
+
+    function getMainnetEthConfig() public pure returns (NetworkConfig memory) {
+        return NetworkConfig({
+            name: "Ethereum Mainnet",
+            chainId: ETH_MAINNET_CHAIN_ID
+        });
+    }
+
+    function getSepoliaEthConfig() public pure returns (NetworkConfig memory) {
+        return NetworkConfig({
+            name: "Sepolia Testnet", 
+            chainId: ETH_SEPOLIA_CHAIN_ID
+        });
+    }    function getOrCreateAnvilEthConfig() public returns (NetworkConfig memory) {
+        // Check if we already have a local network config
+        if (localNetworkConfig.chainId != 0) {
+            return localNetworkConfig;
+        }
+
+        localNetworkConfig = NetworkConfig({
+            name: "Anvil Local",
+            chainId: LOCAL_CHAIN_ID
+        });
+
+        return localNetworkConfig;
+    }
+}

--- a/test/HelperConfigTest.t.sol
+++ b/test/HelperConfigTest.t.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+import {HelperConfig} from "../src/HelperConfig.sol";
+
+contract HelperConfigTest is Test {
+    HelperConfig public helper;
+
+    function setUp() public {
+        helper = new HelperConfig();
+    }
+
+    function testActiveNetworkConfig() public {
+        (string memory name, uint256 chainId) = helper.activeNetworkConfig();
+        assertEq(chainId, 31337);
+        assertEq(name, "Anvil Local");
+    }
+
+    function testGetSepoliaConfig() public {
+        HelperConfig.NetworkConfig memory config = helper.getConfigByChainId(11155111);
+        assertEq(config.chainId, 11155111);
+        assertEq(config.name, "Sepolia Testnet");
+    }
+
+    function testGetMainnetConfig() public {
+        HelperConfig.NetworkConfig memory config = helper.getConfigByChainId(1);
+        assertEq(config.chainId, 1);
+        assertEq(config.name, "Ethereum Mainnet");
+    }
+
+    function testConstants() public {
+        assertEq(helper.LOCAL_CHAIN_ID(), 31337);
+        assertEq(helper.ETH_SEPOLIA_CHAIN_ID(), 11155111);
+        assertEq(helper.ETH_MAINNET_CHAIN_ID(), 1);
+    }
+}


### PR DESCRIPTION
## Add HelperConfig for Network Configuration Management

Hi @PatrickAlphaC ! 👋

I remember you mentioning in the Advanced Foundry course that you'd like to add a HelperConfig to the foundry-devops library, but I noticed it hasn't been implemented yet, so I thought I'd give it a try!

I know this isn't 

### What this PR adds:
- Basic `HelperConfig` contract with support for Mainnet, Sepolia, and Anvil networks
- Simple `NetworkConfig` struct with `name` and `chainId` fields
- Network mapping for storage and retrieval of configurations
- `activeNetworkConfig` that automatically sets based on current chain
- tests covering all functionality

### Thinking to implement a way:
- **Project-specific configurations**: Users could extend NetworkConfig with fields relevant to their specific project (price feeds, token addresses, etc.)
- **Integration with existing DevOpsTools**: Helper methods for common deployment patterns

### Usage Example:
```solidity
import {HelperConfig} from "foundry-devops/src/HelperConfig.sol";

contract MyDeployScript is Script {
    function run() public {
        HelperConfig helperConfig = new HelperConfig();
        HelperConfig.NetworkConfig memory config = helperConfig.getConfigByChainId(block.chainid);
        
    }
}